### PR TITLE
Move sample data to SQL seed script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,18 @@ Aplicación web en ASP.NET Core para gestionar el inventario de una cervecería 
    
 2. Asegura una instancia de PostgreSQL accesible. Por defecto el proyecto usa la cadena `Host=localhost;Database=embrujocervezadb;Username=postgres;Password=postgres;`, que puedes adaptar en `appsettings.json`. En entornos hospedados define la variable `DATABASE_URL` (o `ConnectionStrings__DefaultConnection`) con la URL proporcionada por tu proveedor; la aplicación la normaliza automáticamente al formato que espera Npgsql.
 
-3. Ejecutar la aplicación web:
+3. (Opcional) Cargar datos iniciales en la base:
+   ```bash
+   psql "Host=localhost;Database=embrujocervezadb;Username=postgres;Password=postgres" \
+     -f database/seed-data.sql
+   ```
+   Ajusta la cadena de conexión al servidor que estés utilizando. El script añade los estilos, tipos de botella y lotes de ejemplo sin duplicarlos si ya existen.
+
+4. Ejecutar la aplicación web:
    ```bash
    dotnet run --project src/EmbrujoCerveza.Web
    ```
-4. Abrir un navegador y navegar a `https://localhost:7248` (o la URL indicada por la consola).
+5. Abrir un navegador y navegar a `https://localhost:7248` (o la URL indicada por la consola).
 
 Las imágenes cargadas se almacenan en `wwwroot/uploads`. Este directorio está incluido en el control de versiones mediante un marcador `.gitkeep`, pero los archivos subidos se omiten por el `.gitignore`.
 

--- a/database/seed-data.sql
+++ b/database/seed-data.sql
@@ -1,0 +1,22 @@
+-- Datos de ejemplo para Embrujo Cerveza
+-- Ejecutar este script en la base de datos PostgreSQL luego de aplicar las migraciones.
+
+BEGIN;
+
+INSERT INTO "BeerStyles" ("Id", "Name", "Description", "Abv", "Ibu", "ImageFileName") VALUES
+    (1, 'IPA', 'India Pale Ale con notas cítricas y amargor medio-alto.', 6.2, 55, NULL),
+    (2, 'Stout de avena', 'Cerveza oscura y cremosa con sabores a café y chocolate.', 5.8, 35, NULL)
+ON CONFLICT ("Id") DO NOTHING;
+
+INSERT INTO "BottleTypes" ("Id", "Material", "CapacityMl", "Description") VALUES
+    (1, 'Vidrio ámbar', 330, 'Botella estándar ideal para estilos lupulados.'),
+    (2, 'Lata de aluminio', 473, 'Formato práctico para lotes pequeños.'),
+    (3, 'Vidrio ámbar', 500, 'Presentación clásica para stouts y cervezas especiales.')
+ON CONFLICT ("Id") DO NOTHING;
+
+INSERT INTO "BeerLots" ("Id", "BeerStyleId", "BottleTypeId", "BottleCount", "BottledOn", "Notes") VALUES
+    (1, 1, 1, 120, CURRENT_DATE - INTERVAL '10 days', 'Lote principal de temporada.'),
+    (2, 2, 2, 60, CURRENT_DATE - INTERVAL '3 days', 'Producción limitada.')
+ON CONFLICT ("Id") DO NOTHING;
+
+COMMIT;

--- a/src/EmbrujoCerveza.Web/Program.cs
+++ b/src/EmbrujoCerveza.Web/Program.cs
@@ -1,5 +1,4 @@
 using EmbrujoCerveza.Web.Data;
-using EmbrujoCerveza.Web.Models;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
 
@@ -25,82 +24,6 @@ using (var scope = app.Services.CreateScope())
     var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
     context.Database.Migrate();
 
-    if (!context.BeerStyles.Any())
-    {
-        context.BeerStyles.AddRange(
-            new BeerStyle
-            {
-                Name = "IPA",
-                Description = "India Pale Ale con notas cítricas y amargor medio-alto.",
-                Abv = 6.2m,
-                Ibu = 55
-            },
-            new BeerStyle
-            {
-                Name = "Stout de avena",
-                Description = "Cerveza oscura y cremosa con sabores a café y chocolate.",
-                Abv = 5.8m,
-                Ibu = 35
-            });
-
-        context.SaveChanges();
-    }
-
-    if (!context.BottleTypes.Any())
-    {
-        context.BottleTypes.AddRange(
-            new BottleType
-            {
-                Material = "Vidrio ámbar",
-                CapacityMl = 330,
-                Description = "Botella estándar ideal para estilos lupulados."
-            },
-            new BottleType
-            {
-                Material = "Lata de aluminio",
-                CapacityMl = 473,
-                Description = "Formato práctico para lotes pequeños."
-            },
-            new BottleType
-            {
-                Material = "Vidrio ámbar",
-                CapacityMl = 500,
-                Description = "Presentación clásica para stouts y cervezas especiales."
-            });
-
-        context.SaveChanges();
-    }
-
-    if (!context.BeerLots.Any())
-    {
-        var ipa = context.BeerStyles.FirstOrDefault(s => s.Name == "IPA");
-        var stout = context.BeerStyles.FirstOrDefault(s => s.Name == "Stout de avena");
-        var bottle330 = context.BottleTypes.FirstOrDefault(b => b.CapacityMl == 330);
-        var can473 = context.BottleTypes.FirstOrDefault(b => b.CapacityMl == 473);
-
-        if (ipa != null && stout != null && bottle330 != null && can473 != null)
-        {
-            context.BeerLots.AddRange(
-                new BeerLot
-                {
-                    BeerStyleId = ipa.Id,
-                    BottleTypeId = bottle330.Id,
-                    BottleCount = 120,
-                    BottledOn = DateTime.Today.AddDays(-10),
-                    Notes = "Lote principal de temporada."
-                },
-                new BeerLot
-                {
-                    BeerStyleId = stout.Id,
-                    BottleTypeId = can473.Id,
-                    BottleCount = 60,
-                    BottledOn = DateTime.Today.AddDays(-3),
-                    Notes = "Producción limitada."
-                });
-
-            context.SaveChanges();
-        }
-    }
 }
 
 if (!app.Environment.IsDevelopment())


### PR DESCRIPTION
## Summary
- remove the hard-coded data seeding logic from Program.cs so the app only applies migrations at startup
- add a PostgreSQL SQL script with the initial beer styles, bottle types, and lots that can be executed directly against the database
- document the optional seed script execution step in the README

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8b42100d483339a6bf5e3d358d928